### PR TITLE
Fix idaxml set_member_cmt func call

### DIFF
--- a/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
+++ b/GhidraBuild/IDAPro/Python/7xx/python/idaxml.py
@@ -3111,11 +3111,11 @@ class XmlImporter(IdaXml):
         """
         regcmt = member.find(REGULAR_CMT)
         if regcmt != None:
-            idc.set_member_cmt(mbr, regcmt.text, False)
+            ida_struct.set_member_cmt(mbr, regcmt.text, False)
             self.update_counter(MEMBER + ':' + REGULAR_CMT)
         rptcmt = member.find(REPEATABLE_CMT)
         if rptcmt != None:
-            idc.set_member_cmt(mbr, rptcmt.text, True)
+            ida_struct.set_member_cmt(mbr, rptcmt.text, True)
             self.update_counter(MEMBER + ':' + REPEATABLE_CMT)
         
 


### PR DESCRIPTION
The script originally was incorrectly calling `idc.set_member_cmt` which
takes different arguments to calculate the member struct and offset. And
then it passes the results into the `ida_struct` version. However, this is
already done, so we can just go straight to the `ida_struct` version.